### PR TITLE
Fix unnecessary env access by using Promise.resolve().then

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,0 @@
-export { nextTick } from "https://deno.land/std@0.84.0/node/process.ts";

--- a/semaphore.ts
+++ b/semaphore.ts
@@ -1,5 +1,3 @@
-import { nextTick } from "./deps.ts";
-
 export class Semaphore {
   private tasks: (() => void)[] = [];
   count: number;
@@ -37,7 +35,7 @@ export class Semaphore {
         });
       };
       this.tasks.push(task);
-      nextTick(this.schedule.bind(this));
+      Promise.resolve().then(this.schedule.bind(this));
     });
   }
 

--- a/semaphore_test.ts
+++ b/semaphore_test.ts
@@ -1,4 +1,4 @@
-import { assert, assertEquals, delay, nextTickPromise } from "./test_deps.ts";
+import { assert, assertEquals, delay } from "./test_deps.ts";
 import { Semaphore } from "./mod.ts";
 
 Deno.test("limits concurrency", async function () {
@@ -40,18 +40,17 @@ Deno.test("use recovers from thrown exception", async function () {
   var running = 0;
   var ran = 0;
   var erred = 0;
-  var task = (i: number) =>
-    async () => {
-      assert(running <= 1);
-      running++;
-      await delay(10);
-      assert(running <= 2);
-      running--;
-      if (i === 2) {
-        throw new Error("bogus");
-      }
-      ran++;
-    };
+  var task = (i: number) => async () => {
+    assert(running <= 1);
+    running++;
+    await delay(10);
+    assert(running <= 2);
+    running--;
+    if (i === 2) {
+      throw new Error("bogus");
+    }
+    ran++;
+  };
   await s.use(task(1));
   try {
     await s.use(task(2));
@@ -139,15 +138,18 @@ Deno.test("should not exceed limit", async () => {
   });
 
   assertEquals(s.length, 5);
-  await nextTickPromise();
+  await Promise.resolve();
+  await Promise.resolve();
   assertEquals(ran, 3);
-  await nextTickPromise();
+  await Promise.resolve();
+  await Promise.resolve();
   assertEquals(ran, 3);
   assertEquals(s.length, 2);
 
   releaseHandles.forEach((r) => r());
 
-  await nextTickPromise();
+  await Promise.resolve();
+  await Promise.resolve();
   assertEquals(ran, 5);
   assertEquals(s.length, 0);
 });

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -1,13 +1,5 @@
-import { nextTick } from "./deps.ts";
-
 export {
   assert,
   assertEquals,
 } from "https://deno.land/std@0.84.0/testing/asserts.ts";
 export { delay } from "https://deno.land/std@0.84.0/async/delay.ts";
-
-export function nextTickPromise() {
-  return new Promise((resolve) => {
-    nextTick(() => resolve(true));
-  });
-}


### PR DESCRIPTION
Hi @jd1378

This library requests full access to environment variables unnecessarily, because of the way the nodejs process is polyfilled.

I propose fixing this by replacing `nextTick` with `Promise.resolve().then`, eliminating the need for this dependency.

Also reduces the library from 5.8kB to 1.5kB :).